### PR TITLE
Tools.reader 1.0.0-alpha3 bump

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,6 @@
                                     "dev-resources/private/test/node/compiled"         ;; node-test, node-simple-test
                                     "resources/public/js/compiled"                     ;; min
                                     "out" :target-path]
-  :source-paths ["src/cljs"]
   :hooks [leiningen.cljsbuild]
   :min-lein-version "2.0.0"
   :jvm-opts ^:replace ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xverify:none"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.228"]
-                 [org.clojure/tools.reader "1.0.0-alpha2"]
+                 [org.clojure/tools.reader "1.0.0-alpha3"]
                  [com.cognitect/transit-cljs "0.8.220"]]
 
   :plugins [[lein-cljsbuild "1.1.1"]

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -62,7 +62,10 @@
   "Try to read a string binding all the standard data readers. This
   function throws if a valid form cannot be found."
   [line]
-  (binding [r/*data-readers* tags/*cljs-data-readers*]
+  (binding [ana/*cljs-ns* (:current-ns @app-env)
+            env/*compiler* st
+            r/*data-readers* tags/*cljs-data-readers*
+            r/resolve-symbol ana/resolve-symbol]
     (r/read-string {:read-cond :allow :features #{:cljs}} line)))
 
 (defn ns-form?

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -634,14 +634,18 @@
                                    read-file-fn!
                                    (fn [result]
                                      (if result
-                                       (let [source (:source result)
-                                             rdr (rt/source-logging-push-back-reader source)]
-                                         (dotimes [_ (dec (:line var))] (rt/read-line rdr))
-                                         (-> (r/read {:read-cond :allow :features #{:cljs}} rdr)
-                                             meta
-                                             :source
-                                             common/wrap-success
-                                             cb))
+                                       (binding [ana/*cljs-ns* (:current-ns @app-env)
+                                                 env/*compiler* st
+                                                 r/*data-readers* tags/*cljs-data-readers*
+                                                 r/resolve-symbol ana/resolve-symbol]
+                                         (let [source (:source result)
+                                               rdr (rt/source-logging-push-back-reader source)]
+                                           (dotimes [_ (dec (:line var))] (rt/read-line rdr))
+                                           (-> (r/read {:read-cond :allow :features #{:cljs}} rdr)
+                                               meta
+                                               :source
+                                               common/wrap-success
+                                               cb)))
                                        (cb (common/wrap-success "nil")))))
     (do (when verbose
           (common/debug-prn "No :read-file-fn! provided, skipping source fetching..."))

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -417,7 +417,7 @@ select-keys
           out (unwrap-result res)]
       (is (success? res) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould succeed")
       (is (valid-eval-result? out) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould have a valid result")
-      (is (= "(inc 13)" out) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould return (inc 13)")
+      (is (= "(cljs.core/inc 13)" out) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould return (cljs.core/inc 13)")
       (reset-env!))
 
     (let [res (do (read-eval-call "(ns foo.core$macros)")

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -407,26 +407,26 @@ select-keys
     ;; (it's not that I don't trust Mike, you know)
     (let [res (read-eval-call "(defmacro hello [x] `(inc ~x))")
           out (unwrap-result res)]
-      (is (success? res) "(defmacro hello ..) should succeed")
-      (is (valid-eval-result? out) "(defmacro hello ..) should have a valid result")
-      (is (= "true" out) "(defmacro hello ..) should return true")
+      (is (success? res) "(defmacro hello [x] `(inc ~x)) should succeed")
+      (is (valid-eval-result? out) "(defmacro hello [x] `(inc ~x)) should have a valid result")
+      (is (= "true" out) "(defmacro hello [x] `(inc ~x)) should return true")
       (reset-env!))
 
     (let [res (do (read-eval-call "(defmacro hello [x] `(inc ~x))")
                   (read-eval-call "(hello nil nil 13)"))
           out (unwrap-result res)]
-      (is (success? res) "Executing (defmacro hello ..) as function should succeed")
-      (is (valid-eval-result? out) "Executing (defmacro hello ..) as function should have a valid result")
-      (is (= "(inc 13)" out) "Executing (defmacro hello ..) as function should return (inc 13)")
+      (is (success? res) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould succeed")
+      (is (valid-eval-result? out) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould have a valid result")
+      (is (= "(inc 13)" out) "(defmacro hello [x] `(inc ~x))\n(hello nil nil 13)\nshould return (inc 13)")
       (reset-env!))
 
     (let [res (do (read-eval-call "(ns foo.core$macros)")
                   (read-eval-call "(defmacro hello [x] (prn &form) `(inc ~x))")
                   (read-eval-call "(foo.core/hello (+ 2 3))"))
           out (unwrap-result res)]
-      (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
-      (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
-      (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function should return 6")
+      (is (success? res) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(foo.core/hello (+ 2 3)) should succeed")
+      (is (valid-eval-result? out) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(foo.core/hello (+ 2 3)) should have a valid result")
+      (is (= "6" out) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(foo.core/hello (+ 2 3)) should return 6")
       (reset-env! '[foo.core]))
 
     (let [res (do (read-eval-call "(ns foo.core$macros)")
@@ -435,9 +435,9 @@ select-keys
                   (read-eval-call "(require-macros '[foo.core :refer [hello]])")
                   (read-eval-call "(hello (+ 2 3))"))
           out (unwrap-result res)]
-      (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
-      (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
-      (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function should return 6")
+      (is (success? res) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(ns another.ns)\n(require-macros '[foo.core :refer [hello]])\n(hello (+ 2 3))\nshould succeed")
+      (is (valid-eval-result? out) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(ns another.ns)\n(require-macros '[foo.core :refer [hello]])\n(hello (+ 2 3))\nshould have a valid result")
+      (is (= "6" out) "(ns foo.core$macros)\n(defmacro hello [x] (prn &form) `(inc ~x))\n(ns another.ns)\n(require-macros '[foo.core :refer [hello]])\n(hello (+ 2 3))\nshould return 6")
       (reset-env! '[foo.core another.ns])))
 
   (deftest tagged-literals

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -326,7 +326,17 @@ select-keys
       (is (valid-eval-result? out) "(require '[foo.bar.baz :refer [referred-a]]) from foo.bar should be a valid result")
       (is (= 'foo.bar (repl/current-ns)) "(require '[foo.bar.baz :refer [referred-a]]) from foo.bar should not change namespace")
       (is (= "3" out) "(require '[foo.bar.baz :refer [referred-a]]) from foo.bar should retrieve the interned var value")
-      (reset-env! '[foo.bar foo.bar.baz])))
+      (reset-env! '[foo.bar foo.bar.baz]))
+
+    ;; https://github.com/Lambda-X/replumb/issues/117
+    ;; To uncomment when the source path will include cljs.tools.reader.reader-types
+    (let [res (do (read-eval-call "(require '[cljs.tools.reader :as r])")
+                  (read-eval-call "(binding [r/resolve-symbol (constantly 'cljs.user/x)] (r/read-string \"`x\"))"))
+          out (unwrap-result res)]
+      (is (success? res) "Test for issues #117 should succeed")
+      (is (valid-eval-result? out) "Test for issues #117 should be a valid result")
+      (is (= "(quote cljs.user/x)" out) "Test for issues #117 should return (quote cljs.user/x)")
+      (reset-env! '[cljs.tools.reader])))
 
   (deftest warnings
     ;; AR - The only missing is because you can't have an error and a warning at the same time.

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -329,7 +329,6 @@ select-keys
       (reset-env! '[foo.bar foo.bar.baz]))
 
     ;; https://github.com/Lambda-X/replumb/issues/117
-    ;; To uncomment when the source path will include cljs.tools.reader.reader-types
     (let [res (do (read-eval-call "(require '[cljs.tools.reader :as r])")
                   (read-eval-call "(binding [r/resolve-symbol (constantly 'cljs.user/x)] (r/read-string \"`x\"))"))
           out (unwrap-result res)]


### PR DESCRIPTION
This PR was also supposed to quickly bump `tools.reader` to `1.0.0-alpha3` but it seems there are problems with the tests.

@tomasz-biernacki the section is `macro` and I would like to ask if you can give me some hint on how to debug them :smile: 